### PR TITLE
Implement base API endpoints

### DIFF
--- a/unihub_backend/resources/serializers.py
+++ b/unihub_backend/resources/serializers.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers
+from .models import Category, Tag, Resource, Attachment
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = ['id', 'name', 'slug', 'description', 'parent_category']
+
+class TagSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tag
+        fields = ['id', 'name', 'slug']
+
+class AttachmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Attachment
+        fields = ['id', 'file', 'file_type', 'upload_date']
+
+class ResourceSerializer(serializers.ModelSerializer):
+    attachments = AttachmentSerializer(many=True, read_only=True)
+    tags = TagSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Resource
+        fields = [
+            'id', 'title', 'description', 'uploader', 'category', 'tags',
+            'status', 'upload_date', 'last_modified_date', 'view_count',
+            'download_count', 'attachments'
+        ]
+        read_only_fields = ['uploader', 'view_count', 'download_count']

--- a/unihub_backend/resources/urls.py
+++ b/unihub_backend/resources/urls.py
@@ -1,0 +1,10 @@
+from rest_framework.routers import DefaultRouter
+from .views import CategoryViewSet, TagViewSet, ResourceViewSet, AttachmentViewSet
+
+router = DefaultRouter()
+router.register(r'categories', CategoryViewSet)
+router.register(r'tags', TagViewSet)
+router.register(r'resources', ResourceViewSet)
+router.register(r'attachments', AttachmentViewSet)
+
+urlpatterns = router.urls

--- a/unihub_backend/resources/views.py
+++ b/unihub_backend/resources/views.py
@@ -1,3 +1,31 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .models import Category, Tag, Resource, Attachment
+from .serializers import (
+    CategorySerializer,
+    TagSerializer,
+    ResourceSerializer,
+    AttachmentSerializer,
+)
 
-# Create your views here.
+class CategoryViewSet(viewsets.ModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+class TagViewSet(viewsets.ModelViewSet):
+    queryset = Tag.objects.all()
+    serializer_class = TagSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+class ResourceViewSet(viewsets.ModelViewSet):
+    queryset = Resource.objects.all()
+    serializer_class = ResourceSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def perform_create(self, serializer):
+        serializer.save(uploader=self.request.user)
+
+class AttachmentViewSet(viewsets.ModelViewSet):
+    queryset = Attachment.objects.all()
+    serializer_class = AttachmentSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/unihub_backend/unihub_project/urls.py
+++ b/unihub_backend/unihub_project/urls.py
@@ -34,9 +34,9 @@ urlpatterns = [
     # JWT Token Endpoints
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    # App URLs (to be created later)
-    # path('api/v1/users/', include('users.urls')),
-    # path('api/v1/resources/', include('resources.urls')),
+    # App URLs
+    path('api/v1/users/', include('users.urls')),
+    path('api/v1/resources/', include('resources.urls')),
 ]
 
 # Serve media files during development

--- a/unihub_backend/users/serializers.py
+++ b/unihub_backend/users/serializers.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email']
+
+class RegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'password']
+
+    def create(self, validated_data):
+        user = User.objects.create_user(
+            username=validated_data['username'],
+            email=validated_data.get('email'),
+            password=validated_data['password']
+        )
+        return user

--- a/unihub_backend/users/urls.py
+++ b/unihub_backend/users/urls.py
@@ -1,0 +1,11 @@
+from rest_framework.routers import DefaultRouter
+from django.urls import path
+from .views import UserViewSet, RegisterView
+
+router = DefaultRouter()
+router.register(r'', UserViewSet)
+
+urlpatterns = [
+    path('register/', RegisterView.as_view(), name='register'),
+]
+urlpatterns += router.urls

--- a/unihub_backend/users/views.py
+++ b/unihub_backend/users/views.py
@@ -1,3 +1,13 @@
-from django.shortcuts import render
+from django.contrib.auth.models import User
+from rest_framework import viewsets, permissions, generics
+from .serializers import UserSerializer, RegisterSerializer
 
-# Create your views here.
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class RegisterView(generics.CreateAPIView):
+    queryset = User.objects.all()
+    serializer_class = RegisterSerializer
+    permission_classes = [permissions.AllowAny]


### PR DESCRIPTION
## Summary
- add Django REST serializers for resources
- create resource API endpoints
- expose endpoints for user registration and retrieval
- include URLs in main project

## Testing
- `python3 unihub_backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68400664c77883208e3f7517588dc8bd