### PR TITLE
Enhance backend filtering and clean HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,5 +38,3 @@
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
-    <link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>

--- a/unihub_backend/poetry.lock
+++ b/unihub_backend/poetry.lock
@@ -73,6 +73,21 @@ asgiref = ">=3.6"
 django = ">=4.2"
 
 [[package]]
+name = "django-filter"
+version = "25.1"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80"},
+    {file = "django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153"},
+]
+
+[package.dependencies]
+Django = ">=4.2"
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.0"
 description = "Web APIs for Django, made easy."
@@ -656,4 +671,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "9bd502bfa79bdbc710c1d377057f379f38f0a6ee5fede7b943fb0c7e5e0fba3e"
+content-hash = "86634b8afddf8efa5524c947c06d2ec688cb5abd333b62cfa213cfe501b03bb3"

--- a/unihub_backend/pyproject.toml
+++ b/unihub_backend/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "python-decouple",
     "pillow",
     "django-cors-headers",
-    "drf-spectacular"
+    "drf-spectacular",
+    "django-filter"
 ]
 
 

--- a/unihub_backend/resources/tests.py
+++ b/unihub_backend/resources/tests.py
@@ -1,3 +1,33 @@
-from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from .models import Category, Resource
+
+
+class ResourceAPITestCase(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.category1 = Category.objects.create(name="Cat1")
+        self.category2 = Category.objects.create(name="Cat2")
+        self.resource1 = Resource.objects.create(
+            title="Res1",
+            description="Desc1",
+            uploader=self.user,
+            category=self.category1,
+            status="approved",
+        )
+        self.resource2 = Resource.objects.create(
+            title="Res2",
+            description="Desc2",
+            uploader=self.user,
+            category=self.category2,
+            status="approved",
+        )
+
+    def test_filter_by_category(self):
+        url = reverse("resource-list")
+        response = self.client.get(url, {"category": self.category1.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.resource1.id)

--- a/unihub_backend/resources/views.py
+++ b/unihub_backend/resources/views.py
@@ -21,6 +21,10 @@ class ResourceViewSet(viewsets.ModelViewSet):
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    filterset_fields = ['category', 'tags', 'uploader', 'status']
+    search_fields = ['title', 'description']
+    ordering_fields = ['upload_date', 'view_count', 'download_count']
+    ordering = ['-upload_date']
 
     def perform_create(self, serializer):
         serializer.save(uploader=self.request.user)

--- a/unihub_backend/unihub_project/settings.py
+++ b/unihub_backend/unihub_project/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'corsheaders',
     'drf_spectacular',
+    'django_filters',
     # Local apps
     'users.apps.UsersConfig',
     'resources.apps.ResourcesConfig',
@@ -143,6 +144,11 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter',
+        'rest_framework.filters.OrderingFilter',
+    ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 


### PR DESCRIPTION
## Summary
- add `django-filter` dependency
- enable filter/search/order backend defaults
- extend `ResourceViewSet` with filtering configuration
- add API test for resource filtering
- remove stray tags from `index.html`

## Testing
- `poetry run python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68411fe43ab88320ae8a1dbb8c8bb2f1