### PR TITLE
Add API integration and expand tests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { LanguageProvider } from './contexts/LanguageContext';
 import Navbar from './components/Navbar';
 import CategorySidebar from './components/CategorySidebar';
@@ -8,13 +8,44 @@ import UploadForm from './components/UploadForm';
 import AISearch from './components/AISearch';
 import Footer from './components/Footer';
 import { mockResources } from './data/mockResources';
-import { ResourceCategory } from './types';
+import { ResourceCategory, Resource } from './types';
+import { fetchResources, BackendResource } from './services/apiService';
 
 type AppSection = 'browse' | 'upload' | 'ai-search';
 
 const App: React.FC = () => {
   const [currentSection, setCurrentSection] = useState<AppSection>('browse');
   const [selectedCategory, setSelectedCategory] = useState<ResourceCategory | null>(null);
+  const [resources, setResources] = useState<Resource[]>(mockResources);
+
+  useEffect(() => {
+    fetchResources()
+      .then((data: BackendResource[]) => {
+        const mapped: Resource[] = data.map((r) => ({
+          id: String(r.id),
+          title: {
+            'zh-CN': r.title,
+            'zh-TW': r.title,
+            'en-US': r.title,
+            'fr-FR': r.title,
+          },
+          description: {
+            'zh-CN': r.description,
+            'zh-TW': r.description,
+            'en-US': r.description,
+            'fr-FR': r.description,
+          },
+          category: ResourceCategory.POSTGRADUATE_ADVANCEMENT,
+          uploader: String(r.uploader ?? ''),
+          uploadDate: r.upload_date,
+          tags: [],
+        }));
+        setResources(mapped);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch resources', err);
+      });
+  }, []);
 
   const renderMainContent = () => {
     switch (currentSection) {
@@ -23,7 +54,7 @@ const App: React.FC = () => {
           <div className="flex flex-1 overflow-hidden">
             <CategorySidebar selectedCategory={selectedCategory} onSelectCategory={setSelectedCategory} />
             <main className="flex-1 p-6 overflow-y-auto bg-gray-50">
-              <ResourceList resources={mockResources} selectedCategory={selectedCategory} />
+              <ResourceList resources={resources} selectedCategory={selectedCategory} />
             </main>
           </div>
         );

--- a/index.html
+++ b/index.html
@@ -38,5 +38,3 @@
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>
-    <link rel="stylesheet" href="index.css">
-<script src="index.tsx" type="module"></script>

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -1,0 +1,20 @@
+export interface BackendResource {
+  id: number;
+  title: string;
+  description: string;
+  uploader: number | null;
+  category: number | null;
+  status: string;
+  upload_date: string;
+  last_modified_date: string;
+  view_count: number;
+  download_count: number;
+}
+
+export const fetchResources = async (): Promise<BackendResource[]> => {
+  const res = await fetch('/api/v1/resources/resources/');
+  if (!res.ok) {
+    throw new Error('Failed to fetch resources');
+  }
+  return res.json();
+};

--- a/unihub_backend/poetry.lock
+++ b/unihub_backend/poetry.lock
@@ -73,6 +73,21 @@ asgiref = ">=3.6"
 django = ">=4.2"
 
 [[package]]
+name = "django-filter"
+version = "25.1"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80"},
+    {file = "django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153"},
+]
+
+[package.dependencies]
+Django = ">=4.2"
+
+[[package]]
 name = "djangorestframework"
 version = "3.16.0"
 description = "Web APIs for Django, made easy."
@@ -656,4 +671,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "9bd502bfa79bdbc710c1d377057f379f38f0a6ee5fede7b943fb0c7e5e0fba3e"
+content-hash = "86634b8afddf8efa5524c947c06d2ec688cb5abd333b62cfa213cfe501b03bb3"

--- a/unihub_backend/pyproject.toml
+++ b/unihub_backend/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "python-decouple",
     "pillow",
     "django-cors-headers",
-    "drf-spectacular"
+    "drf-spectacular",
+    "django-filter"
 ]
 
 

--- a/unihub_backend/resources/tests.py
+++ b/unihub_backend/resources/tests.py
@@ -1,3 +1,50 @@
-from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from .models import Category, Resource
+
+
+class ResourceAPITestCase(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.category1 = Category.objects.create(name="Cat1")
+        self.category2 = Category.objects.create(name="Cat2")
+        self.resource1 = Resource.objects.create(
+            title="Res1",
+            description="Desc1",
+            uploader=self.user,
+            category=self.category1,
+            status="approved",
+        )
+        self.resource2 = Resource.objects.create(
+            title="Res2",
+            description="Desc2",
+            uploader=self.user,
+            category=self.category2,
+            status="approved",
+        )
+
+    def test_filter_by_category(self):
+        url = reverse("resource-list")
+        response = self.client.get(url, {"category": self.category1.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.resource1.id)
+
+    def test_search_by_title(self):
+        url = reverse("resource-list")
+        response = self.client.get(url, {"search": "Res2"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.resource2.id)
+
+    def test_order_by_view_count(self):
+        self.resource1.view_count = 10
+        self.resource1.save()
+        self.resource2.view_count = 5
+        self.resource2.save()
+        url = reverse("resource-list")
+        response = self.client.get(url, {"ordering": "-view_count"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["id"], self.resource1.id)

--- a/unihub_backend/resources/views.py
+++ b/unihub_backend/resources/views.py
@@ -21,6 +21,10 @@ class ResourceViewSet(viewsets.ModelViewSet):
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    filterset_fields = ['category', 'tags', 'uploader', 'status']
+    search_fields = ['title', 'description']
+    ordering_fields = ['upload_date', 'view_count', 'download_count']
+    ordering = ['-upload_date']
 
     def perform_create(self, serializer):
         serializer.save(uploader=self.request.user)

--- a/unihub_backend/unihub_project/settings.py
+++ b/unihub_backend/unihub_project/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'corsheaders',
     'drf_spectacular',
+    'django_filters',
     # Local apps
     'users.apps.UsersConfig',
     'resources.apps.ResourcesConfig',
@@ -143,6 +144,11 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter',
+        'rest_framework.filters.OrderingFilter',
+    ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 

--- a/unihub_backend/users/tests.py
+++ b/unihub_backend/users/tests.py
@@ -1,3 +1,18 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+class RegistrationAPITestCase(APITestCase):
+    def test_register_user(self):
+        url = reverse('register')
+        data = {'username': 'newuser', 'email': 'new@example.com', 'password': 'pass1234'}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(User.objects.filter(username='newuser').exists())
+
+    def test_obtain_token(self):
+        User.objects.create_user(username='tester', password='secret')
+        url = reverse('token_obtain_pair')
+        response = self.client.post(url, {'username': 'tester', 'password': 'secret'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('access', response.data)


### PR DESCRIPTION
## Summary
- implement frontend API service and use it in App
- expand resource API tests with search and ordering
- add user registration and token tests

## Testing
- `poetry run python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68411fe43ab88320ae8a1dbb8c8bb2f1