### PR TITLE
Use import.meta.env for API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your-api-key-here
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env.local` and set the `GEMINI_API_KEY` value
 3. Run the app:
    `npm run dev`

--- a/index.html
+++ b/index.html
@@ -22,18 +22,12 @@
 </head>
   <body class="bg-gray-100">
     <div id="root"></div>
-    <script>
-      // Initialize process.env.API_KEY for the purpose of this example.
-      // In a real application, this would be set through environment variables
-      // by the build system or server. It SHOULD NOT be hardcoded in production.
+    <script type="module">
+      // Expose the Gemini API key provided via Vite's environment injection.
       if (typeof process === 'undefined') {
         window.process = { env: {} };
       }
-      // IMPORTANT: Replace "YOUR_GEMINI_API_KEY" with an actual API key if you intend to run this.
-      // For this generated code, we are providing a placeholder.
-      // The instructions state to assume process.env.API_KEY is pre-configured.
-      // If it's not set, the Gemini API calls will fail.
-      process.env.API_KEY = "YOUR_GEMINI_API_KEY"; // Placeholder
+      process.env.API_KEY = import.meta.env.GEMINI_API_KEY;
     </script>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,10 +2,10 @@
 import { GoogleGenAI, GenerateContentResponse, GroundingMetadata } from "@google/genai";
 import { GEMINI_MODEL_TEXT } from '../constants';
 
-const API_KEY = process.env.API_KEY;
+const API_KEY = import.meta.env.GEMINI_API_KEY;
 
 if (!API_KEY) {
-  console.error("Gemini API key is missing. Please set the process.env.API_KEY environment variable.");
+  console.error("Gemini API key is missing. Please set GEMINI_API_KEY in your .env.local file.");
 }
 
 const ai = new GoogleGenAI({ apiKey: API_KEY || "MISSING_API_KEY" });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'import.meta.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- use Vite's env injection to expose `GEMINI_API_KEY`
- document env variable and .env.local setup
- add `.env.example`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68423214f9308320906a8c184dbb3542